### PR TITLE
fix: isolate animation path from data path.

### DIFF
--- a/finitewave/cpuwave2D/tracker/animation_2d_tracker.py
+++ b/finitewave/cpuwave2D/tracker/animation_2d_tracker.py
@@ -39,7 +39,19 @@ class Animation2DTracker(Tracker):
         self.frame_type = "float64"   # Default frame format settings
         self._frame_counter = 0       # Internal frame counter
         self.overwrite = True         # Overwrite existing frames
-        self.file_name = "animation"  # Name of the animation file
+        self._file_name = None        # Name of the animation file
+
+    @property
+    def file_name(self):
+        if self._file_name is not None:
+            return self._file_name
+
+        path = Path(self.path, self.dir_name).parent
+        return path / "animation"
+
+    @file_name.setter
+    def file_name(self, file_name):
+        self._file_name = file_name
 
     def initialize(self, model):
         """

--- a/finitewave/tools/animation_2d_builder.py
+++ b/finitewave/tools/animation_2d_builder.py
@@ -41,7 +41,7 @@ class Animation2DBuilder:
             Show progress bar.
         """
         path = Path(path)
-        path_save = path.parent.joinpath(animation_name).with_suffix(".mp4")
+        path_save = Path(animation_name).with_suffix(".mp4")
 
         files = natsorted(path.glob("*.npy"))
 


### PR DESCRIPTION
The path where `2DAnimationTracker` outputs the animation depends on the data path.
It would be more flexible if the animation path could be set independently. For example, it would enable users to store the data en animations in separate subfolders.
I also added a property so that the old behavior is kept when animation path is not provided.